### PR TITLE
Masking custom date of form 'MON HH:MM:SS'

### DIFF
--- a/preprocessing-service/masker.py
+++ b/preprocessing-service/masker.py
@@ -103,6 +103,10 @@ masking_list_before_value_assigning_token_split = [
     {
         "regex_pattern": "[IWEF]\\d{4}\\s\\d{2}:\\d{2}:\\d{2}[\\.\\d+]*",
         "mask_with": "KLOG_DATE",
+    },
+    {
+        "regex_pattern": "(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\\s+(\\d{1,2}) (2[0-3]|[01]?[0-9]):([0-5]?[0-9]):([0-5]?[0-9])",
+        "mask_with": "CUSTOM_DATE"
     }
 ]
 


### PR DESCRIPTION
```
Jun  1 21:36:40 ip-172-31-40-84 k3s[1663]: I0601 21:36:40.499320    1663 event.go:291] "Event occurred" object="default/test-job" kind="Job" apiVersion="batch/v1" type="Normal" reason="SuccessfulCreate" message="Created pod: test-job-pzgf4"
```
was getting preprocessed to 
```
jun <num> <num> : <num> : <num> <token_with_digit> <token_with_digit> : <klog_date> <num> event.go : <token_with_digit> event occurred object = default<path> kind = job apiversion = batch<path> type = normal reason = successfulcreate message = created pod : <token_with_digit>
```

Introduced a new regex pattern which results in above log message preprocessed to
```
<custom_date> <token_with_digit> <token_with_digit> : <klog_date> <num> event.go : <token_with_digit> event occurred object = default<path> kind = job apiversion = batch<path> type = normal reason = successfulcreate message = created pod : <token_with_digit>
```