### PR TITLE
removing time field - will rely on timestamp field

### DIFF
--- a/preprocessing-service/requirements.txt
+++ b/preprocessing-service/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.7.4.post0
 elasticsearch==7.12.0
+numpy==1.20.3
 opni-nats==0.0.0.1
 pandas==1.2.3


### PR DESCRIPTION
Removing the `time` field. `time` is normalized in payload-receiver-service. In preprocessing service, `time` is converted to unix timestamp format in milliseconds and assigned to a field named `timestamp`