### PR TITLE
Update masking list to include go file paths

### DIFF
--- a/preprocessing-service/masker.py
+++ b/preprocessing-service/masker.py
@@ -60,6 +60,10 @@ class RegexMasker:
 
 masking_list = [
     {
+        "regex_pattern": "[^\\s]+.go : [0-9]+",
+        "mask_with": "GO_FILE_PATH"
+    },
+    {
         "regex_pattern": "[a-z0-9]+[\\._]?[a-z0-9]+[@]\\w+[.]\\w{2,3}",
         "mask_with": "EMAIL_ADDRESS",
     },


### PR DESCRIPTION
This PR adds masking instructions for go file paths which are seen within the klog statements for control plane logs. As an example:
```I0120 02:10:17.548439       1 passthrough.go:48] ccResolverWrapper: sending update to cc: {[{https://172.31.14.138:2379  <nil> 0 <nil>}] <nil> <nil>
```
will now be masked to be
```
<klog_date> <num> <go_file_path> ccresolverwrapper : sending update to cc : <url> <nil> <num> <nil> <nil> <nil>
```