### PR TITLE
Apply masking for control plane logs

### DIFF
--- a/preprocessing-service/masker.py
+++ b/preprocessing-service/masker.py
@@ -60,6 +60,10 @@ class RegexMasker:
 
 masking_list = [
     {
+        "regex_pattern": "[^\\s]+.go : [0-9]+",
+        "mask_with": "GO_FILE_PATH"
+    },
+    {
         "regex_pattern": "[a-z0-9]+[\\._]?[a-z0-9]+[@]\\w+[.]\\w{2,3}",
         "mask_with": "EMAIL_ADDRESS",
     },


### PR DESCRIPTION
This PR introduces masking for control plane logs specifically for InfoS log formats and also will mask Go file paths. For example, a message in this format:

I1129 22:26:22.800223       1 deployment/deployment_controller.go:578] "Finished syncing deployment" deployment="opni/opni-svc-metrics" duration="482.277µs"

This will now be masked as:
```
<klog_date> <num> <go_file_path> finished syncing deployment deployment = <deployment> duration = <duration>
```

This PR also removes writing some of the prior Opensearch fields that were related to workload logs as those are currently no longer in use. 