### PR TITLE
Update masking rules in preprocessing service

### DIFF
--- a/preprocessing-service/masker.py
+++ b/preprocessing-service/masker.py
@@ -28,23 +28,10 @@ class RegexMasker:
         self.remove_delimiters = r'([| \(|\)|\[|\]\'|\{|\}|"|,])'
         self.ansi_escape = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]")
 
-    def mask(self, content: str, is_control_plane_log: bool):
+    def mask(self, content: str):
 
         # get rid of escape keys
         content = self.ansi_escape.sub("", content)
-
-        # If log is a control plane log, mask out content from structured control plane log messages which follow the 'a="somecontent" to be a=<a>'
-        if is_control_plane_log:
-            assignment_regex = '([A-z]+)="(.*?)"'
-            matching_indices = [(m.start(0), m.end(0)) for m in re.finditer(assignment_regex, content)]
-            modified_content = content[:]
-
-            for m in matching_indices:
-                substring = content[m[0]:m[1]]
-                left_side_term = substring.split("=\"")[0]
-                if left_side_term != "err":
-                    modified_content = modified_content.replace(substring, "{}=<{}>".format(left_side_term, left_side_term))
-            content = modified_content[:]
 
         for mi in self.masking_instructions_before_value_assign_token_split:
             # content = re.sub(mi.regex, mi.mask_with_wrapped, content)
@@ -143,5 +130,5 @@ class LogMasker:
             masking_instructions_before_value_assigning_token_split,
         )
 
-    def mask(self, content: str, is_control_plane_log: bool):
-        return self.masker.mask(content, is_control_plane_log)
+    def mask(self, content: str):
+        return self.masker.mask(content)

--- a/preprocessing-service/preprocess.py
+++ b/preprocessing-service/preprocess.py
@@ -143,7 +143,7 @@ async def mask_logs(queue):
 
         masked_logs = []
         for index, row in payload_data_df.iterrows():
-            masked_logs.append(masker.mask(row["log"], row["is_control_plane_log"]))
+            masked_logs.append(masker.mask(row["log"]))
         payload_data_df["masked_log"] = masked_logs
         try:
             async for ok, result in async_streaming_bulk(


### PR DESCRIPTION
This PR updates the masking rule for the preprocessing service, removing the rule for InfoS control plane logs and keeping the Go file path masking rule.