### PR TITLE
Add logic for handling workload logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 RUN chmod a+rwx -R /app
 WORKDIR /app
 
-CMD [ "python", "./preprocess.py" ]
+CMD [ "python", "./preprocess.py"]

--- a/preprocessing-service/preprocess.py
+++ b/preprocessing-service/preprocess.py
@@ -35,7 +35,7 @@ async def consume_logs(mask_logs_queue):
 
     async def workload_parameters_handler(msg):
         global workload_parameters_dict
-        workload_parameters_dict = json.loads(msg.data.decode())
+        workload_parameters_dict = json.loads(msg.data.decode())["workloads"]
 
     await nw.subscribe(
         nats_subject="raw_logs",
@@ -45,7 +45,7 @@ async def consume_logs(mask_logs_queue):
     )
 
     await nw.subscribe(
-        nats_subject="workload_parameters",
+        nats_subject="model_workload_parameters",
         nats_queue="workers",
         subscribe_handler=workload_parameters_handler,
     )

--- a/preprocessing-service/preprocess.py
+++ b/preprocessing-service/preprocess.py
@@ -1,6 +1,8 @@
 # Standard Library
 import asyncio
+import json
 import logging
+import sys
 import time
 
 # Third Party
@@ -13,21 +15,22 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(messa
 
 nw = NatsWrapper()
 
-async def consume_logs(mask_logs_queue):
+async def consume_logs(mask_logs_pretrained_queue):
     async def subscribe_handler(msg):
         payload_data = msg.data
         log_payload = Payload()
-        await mask_logs_queue.put(log_payload.parse(payload_data))
+        await mask_logs_pretrained_queue.put(log_payload.parse(payload_data))
 
 
     await nw.subscribe(
         nats_subject="raw_logs",
         nats_queue="workers",
-        payload_queue=mask_logs_queue,
+        payload_queue=mask_logs_pretrained_queue,
         subscribe_handler=subscribe_handler,
     )
 
-async def mask_logs(queue):
+
+async def mask_logs(queue, workload_parameters):
     masker = LogMasker()
     last_time = time.time()
     pending_list = []
@@ -39,39 +42,48 @@ async def mask_logs(queue):
             payload_data_df = pd.DataFrame(pending_list)
             last_time = start_time
             pending_list = []
-            await run(payload_data_df, masker)
+            await run(payload_data_df, masker, workload_parameters)
 
-async def run(payload_data_df, masker):
+async def run(payload_data_df, masker, workload_parameters):
     logging.info(f"processing {len(payload_data_df)} logs...")
     payload_data_df["log"] = payload_data_df["log"].str.strip()
-    masked_logs = []
+    filtered_masked_logs = []
 
     for index, row in payload_data_df.iterrows():
         try:
-            masked_logs.append(masker.mask(row["log"]))
+            if row["log_type"] == "workload":
+                for cluster_id in workload_parameters:
+                    for namespace_name in workload_parameters[cluster_id]:
+                        for pod_name in workload_parameters[cluster_id][namespace_name]:
+                            if cluster_id == row["cluster_id"] and namespace_name == row["namespace_name"] and pod_name == row["pod_name"]:
+                                row["masked_log"] = masker.mask(row["log"])
+                                filtered_masked_logs.append(row)
+            else:
+                row["masked_log"] = masker.mask(row["log"])
+                filtered_masked_logs.append(row)
         except Exception as e:
-            masked_logs.append(row["log"])
-    payload_data_df["masked_log"] = masked_logs
-    pretrained_model_logs_df = payload_data_df.loc[(payload_data_df["log_type"] != "workload")]
-    workload_logs_df = payload_data_df.loc[(payload_data_df["log_type"] == "workload")]
-    logging.info(workload_logs_df["pod_name"])
+            row["masked_log"] = row["log"]
+            filtered_masked_logs.append(row)
+    payload_data_df = pd.DataFrame(filtered_masked_logs)
+    if len(payload_data_df) > 0:
+        pretrained_model_logs_df = payload_data_df.loc[(payload_data_df["log_type"] != "workload")]
+        workload_logs_df = payload_data_df.loc[(payload_data_df["log_type"] == "workload")]
 
+        if len(pretrained_model_logs_df) > 0:
+            pretrained_models_list = list(map(lambda row: Payload(*row), pretrained_model_logs_df.values))
+            protobuf_pretrained_payload = PayloadList(items=pretrained_models_list)
+            await nw.publish(
+                "preprocessed_logs_pretrained_model",
+                bytes(protobuf_pretrained_payload),
+            )
 
-    if len(pretrained_model_logs_df) > 0:
-        pretrained_models_list = list(map(lambda row: Payload(*row), pretrained_model_logs_df.values))
-        protobuf_pretrained_payload = PayloadList(items=pretrained_models_list)
-        await nw.publish(
-            "preprocessed_logs_pretrained_model",
-            bytes(protobuf_pretrained_payload),
-        )
-
-    if len(workload_logs_df) > 0:
-        workload_logs_list = list(map(lambda row: Payload(*row), pretrained_model_logs_df.values))
-        protobuf_workload_payload = PayloadList(items=workload_logs_list)
-        await nw.publish(
-            "preprocessed_logs_workload",
-            bytes(protobuf_workload_payload),
-        )
+        if len(workload_logs_df) > 0:
+            workload_logs_list = list(map(lambda row: Payload(*row), workload_logs_df.values))
+            protobuf_workload_payload = PayloadList(items=workload_logs_list)
+            await nw.publish(
+                "preprocessed_logs_workload",
+                bytes(protobuf_workload_payload),
+            )
 
 async def init_nats():
     logging.info("Attempting to connect to NATS")
@@ -79,10 +91,12 @@ async def init_nats():
 
 
 if __name__ == "__main__":
+    with open("workload_parameters.json","r") as wp:
+        workload_parameters = json.load(wp)
     loop = asyncio.get_event_loop()
     mask_logs_queue = asyncio.Queue(loop=loop)
     nats_consumer_coroutine = consume_logs(mask_logs_queue)
-    mask_logs_coroutine = mask_logs(mask_logs_queue)
+    mask_logs_coroutine = mask_logs(mask_logs_queue, workload_parameters)
 
     task = loop.create_task(init_nats())
     loop.run_until_complete(task)

--- a/preprocessing-service/preprocess.py
+++ b/preprocessing-service/preprocess.py
@@ -53,14 +53,24 @@ async def run(payload_data_df, masker):
             masked_logs.append(row["log"])
     payload_data_df["masked_log"] = masked_logs
     pretrained_model_logs_df = payload_data_df.loc[(payload_data_df["log_type"] != "workload")]
+    workload_logs_df = payload_data_df.loc[(payload_data_df["log_type"] == "workload")]
+    logging.info(workload_logs_df["pod_name"])
 
 
     if len(pretrained_model_logs_df) > 0:
         pretrained_models_list = list(map(lambda row: Payload(*row), pretrained_model_logs_df.values))
-        protobuf_payload = PayloadList(items=pretrained_models_list)
+        protobuf_pretrained_payload = PayloadList(items=pretrained_models_list)
         await nw.publish(
             "preprocessed_logs_pretrained_model",
-            bytes(protobuf_payload),
+            bytes(protobuf_pretrained_payload),
+        )
+
+    if len(workload_logs_df) > 0:
+        workload_logs_list = list(map(lambda row: Payload(*row), pretrained_model_logs_df.values))
+        protobuf_workload_payload = PayloadList(items=workload_logs_list)
+        await nw.publish(
+            "preprocessed_logs_workload",
+            bytes(protobuf_workload_payload),
         )
 
 async def init_nats():

--- a/preprocessing-service/preprocess.py
+++ b/preprocessing-service/preprocess.py
@@ -3,13 +3,11 @@ import asyncio
 import json
 import logging
 import os
-import sys
 import time
 
 # Third Party
 from elasticsearch import AsyncElasticsearch
 from opni_proto.log_anomaly_payload_pb import Payload, PayloadList
-import pandas as pd
 from masker import LogMasker
 from opni_nats import NatsWrapper
 

--- a/preprocessing-service/preprocess.py
+++ b/preprocessing-service/preprocess.py
@@ -2,35 +2,93 @@
 import asyncio
 import json
 import logging
+import os
 import sys
 import time
 
 # Third Party
+from elasticsearch import AsyncElasticsearch
 from opni_proto.log_anomaly_payload_pb import Payload, PayloadList
 import pandas as pd
 from masker import LogMasker
 from opni_nats import NatsWrapper
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(message)s")
-
+workload_parameters_dict = dict()
 nw = NatsWrapper()
 
-async def consume_logs(mask_logs_pretrained_queue):
-    async def subscribe_handler(msg):
+ES_ENDPOINT = os.environ["ES_ENDPOINT"]
+ES_USERNAME = os.getenv("ES_USERNAME", "admin")
+ES_PASSWORD = os.getenv("ES_PASSWORD", "admin")
+
+es_instance = AsyncElasticsearch(
+    [ES_ENDPOINT],
+    port=9200,
+    http_auth=(ES_USERNAME, ES_PASSWORD),
+    verify_certs=False,
+    use_ssl=True,
+)
+
+async def consume_logs(mask_logs_queue):
+    async def pretrained_subscribe_handler(msg):
         payload_data = msg.data
         log_payload = Payload()
-        await mask_logs_pretrained_queue.put(log_payload.parse(payload_data))
+        await mask_logs_queue.put(log_payload.parse(payload_data))
 
+    async def workload_parameters_handler(msg):
+        global workload_parameters_dict
+        workload_parameters_dict = json.loads(msg.data.decode())
+        logging.info(workload_parameters_dict)
 
     await nw.subscribe(
         nats_subject="raw_logs",
         nats_queue="workers",
-        payload_queue=mask_logs_pretrained_queue,
-        subscribe_handler=subscribe_handler,
+        payload_queue=mask_logs_queue,
+        subscribe_handler=pretrained_subscribe_handler,
     )
 
+    await nw.subscribe(
+        nats_subject="workload_parameters",
+        nats_queue="workers",
+        subscribe_handler=workload_parameters_handler,
+    )
 
-async def mask_logs(queue, workload_parameters):
+async def get_latest_workload():
+    global workload_parameters_dict
+    query_body = {"sort": [{"time": {"order": "desc"}}],"query": {"match_all": {}}}
+    try:
+        latest_workload = await es_instance.search(index="model-training-parameters",body=query_body,size=1)
+        workload_parameters_dict = json.loads(latest_workload["hits"]["hits"][0]["_source"]["parameters"])
+    except Exception as e:
+        logging.error(f"{e}")
+
+def verify_workload(payload):
+    logging.info(workload_parameters_dict)
+    logging.info(payload.cluster_id)
+    logging.info(payload.namespace_name)
+    if payload.pod_name == 'paymentservice-78c54474d-7qhff':
+        logging.info("here it is")
+    if payload.pod_name == "paymentservice-78c54474d-7qhff":
+        logging.info("double quotes lies the issue")
+    logging.info("pod name is {}".format(payload.pod_name))
+    for cluster_id in workload_parameters_dict:
+        logging.info(cluster_id)
+        if payload.cluster_id != cluster_id:
+            continue
+        for namespace_name in workload_parameters_dict[cluster_id]:
+            logging.info(namespace_name)
+            if payload.namespace_name != namespace_name:
+                continue
+            for pod_name in workload_parameters_dict[cluster_id][namespace_name]:
+                logging.info(pod_name)
+                if pod_name == payload.pod_name:
+                    logging.info("over here. match made")
+                    logging.info(payload.pod_name)
+                    return True
+    return False
+
+
+async def mask_logs(queue):
     masker = LogMasker()
     last_time = time.time()
     pending_list = []
@@ -39,51 +97,41 @@ async def mask_logs(queue, workload_parameters):
         pending_list.append(payload)
         start_time = time.time()
         if start_time - last_time >= 1 or len(pending_list) >= 128:
-            payload_data_df = pd.DataFrame(pending_list)
+            payload_list = PayloadList(items=pending_list)
             last_time = start_time
             pending_list = []
-            await run(payload_data_df, masker, workload_parameters)
+            await run(payload_list, masker)
 
-async def run(payload_data_df, masker, workload_parameters):
-    logging.info(f"processing {len(payload_data_df)} logs...")
-    payload_data_df["log"] = payload_data_df["log"].str.strip()
-    filtered_masked_logs = []
-
-    for index, row in payload_data_df.iterrows():
+async def run(payload_list, masker):
+    logging.info(f"processing {len(payload_list.items)} logs...")
+    filtered_workload_logs = []
+    filtered_pretrained_logs = []
+    for payload in payload_list.items:
         try:
-            if row["log_type"] == "workload":
-                for cluster_id in workload_parameters:
-                    for namespace_name in workload_parameters[cluster_id]:
-                        for pod_name in workload_parameters[cluster_id][namespace_name]:
-                            if cluster_id == row["cluster_id"] and namespace_name == row["namespace_name"] and pod_name == row["pod_name"]:
-                                row["masked_log"] = masker.mask(row["log"])
-                                filtered_masked_logs.append(row)
+            if payload.log_type == "workload":
+                logging.info("workload log here")
+                if verify_workload(payload):
+                    logging.info(payload.pod_name)
+                    logging.info(workload_parameters_dict)
+                    payload.masked_log = masker.mask(payload.log)
+                    filtered_workload_logs.append(payload)
             else:
-                row["masked_log"] = masker.mask(row["log"])
-                filtered_masked_logs.append(row)
+                logging.info(payload.log_type)
+                payload.masked_log = masker.mask(payload.log)
+                filtered_pretrained_logs.append(payload)
         except Exception as e:
-            row["masked_log"] = row["log"]
-            filtered_masked_logs.append(row)
-    payload_data_df = pd.DataFrame(filtered_masked_logs)
-    if len(payload_data_df) > 0:
-        pretrained_model_logs_df = payload_data_df.loc[(payload_data_df["log_type"] != "workload")]
-        workload_logs_df = payload_data_df.loc[(payload_data_df["log_type"] == "workload")]
+            continue
 
-        if len(pretrained_model_logs_df) > 0:
-            pretrained_models_list = list(map(lambda row: Payload(*row), pretrained_model_logs_df.values))
-            protobuf_pretrained_payload = PayloadList(items=pretrained_models_list)
-            await nw.publish(
-                "preprocessed_logs_pretrained_model",
-                bytes(protobuf_pretrained_payload),
-            )
 
-        if len(workload_logs_df) > 0:
-            workload_logs_list = list(map(lambda row: Payload(*row), workload_logs_df.values))
-            protobuf_workload_payload = PayloadList(items=workload_logs_list)
-            await nw.publish(
-                "preprocessed_logs_workload",
-                bytes(protobuf_workload_payload),
-            )
+    if len(filtered_pretrained_logs) > 0:
+        logging.info("over here.")
+        protobuf_pretrained_payload = PayloadList(items=filtered_pretrained_logs)
+        await nw.publish(
+            "preprocessed_logs_pretrained_model",bytes(protobuf_pretrained_payload),)
+
+    if len(filtered_workload_logs) > 0:
+        protobuf_workload_payload = PayloadList(items=filtered_workload_logs)
+        await nw.publish("preprocessed_logs_workload",bytes(protobuf_workload_payload),)
 
 async def init_nats():
     logging.info("Attempting to connect to NATS")
@@ -91,15 +139,16 @@ async def init_nats():
 
 
 if __name__ == "__main__":
-    with open("workload_parameters.json","r") as wp:
-        workload_parameters = json.load(wp)
     loop = asyncio.get_event_loop()
     mask_logs_queue = asyncio.Queue(loop=loop)
+    workload_parameters_queue = asyncio.Queue(loop=loop)
     nats_consumer_coroutine = consume_logs(mask_logs_queue)
-    mask_logs_coroutine = mask_logs(mask_logs_queue, workload_parameters)
+    mask_logs_coroutine = mask_logs(mask_logs_queue)
 
-    task = loop.create_task(init_nats())
-    loop.run_until_complete(task)
+    init_nats_task = loop.create_task(init_nats())
+    loop.run_until_complete(init_nats_task)
+    latest_workload_task = loop.create_task(get_latest_workload())
+    loop.run_until_complete(latest_workload_task)
 
     loop.run_until_complete(
         asyncio.gather(nats_consumer_coroutine, mask_logs_coroutine)

--- a/preprocessing-service/preprocess.py
+++ b/preprocessing-service/preprocess.py
@@ -118,7 +118,6 @@ async def init_nats():
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()
     mask_logs_queue = asyncio.Queue(loop=loop)
-    workload_parameters_queue = asyncio.Queue(loop=loop)
     nats_consumer_coroutine = consume_logs(mask_logs_queue)
     mask_logs_coroutine = mask_logs(mask_logs_queue)
 

--- a/preprocessing-service/requirements.txt
+++ b/preprocessing-service/requirements.txt
@@ -1,5 +1,5 @@
 elasticsearch[async]==7.13.0
 numpy==1.22.0
 opni-nats==0.0.0.4
-dev-proto==0.6.0.0
+opni-proto==0.6.1.0
 pandas==1.2.3

--- a/preprocessing-service/requirements.txt
+++ b/preprocessing-service/requirements.txt
@@ -1,3 +1,4 @@
+elasticsearch[async]==7.13.0
 numpy==1.22.0
 opni-nats==0.0.0.4
 dev-proto==0.6.0.0

--- a/preprocessing-service/requirements.txt
+++ b/preprocessing-service/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.22.0
 opni-nats==0.0.0.4
-opni-proto==0.5.4.6
+dev-proto==0.6.0.0
 pandas==1.2.3

--- a/preprocessing-service/workload_parameters.json
+++ b/preprocessing-service/workload_parameters.json
@@ -1,1 +1,0 @@
-{"local": {"default": ["cartservice-75f9c7f97c-qvq7k", "emailservice-f6d7bdf48-7d5fw", "productcatalogservice-5f6f784db6-l646n"]}}

--- a/preprocessing-service/workload_parameters.json
+++ b/preprocessing-service/workload_parameters.json
@@ -1,0 +1,1 @@
+{"local": {"default": ["cartservice-75f9c7f97c-qvq7k", "emailservice-f6d7bdf48-7d5fw", "productcatalogservice-5f6f784db6-l646n"]}}


### PR DESCRIPTION
This PR adds logic to the preprocessing logic so that in addition to control plane, Rancher and Longhorn logs, it will also be able to redirect relevant workload logs based on the model training parameters that are specified by the user. 